### PR TITLE
Acacia experiments with python handlers

### DIFF
--- a/core-aam/acacia/resources/acacia.py
+++ b/core-aam/acacia/resources/acacia.py
@@ -3,56 +3,52 @@ import json
 from ua_parser import user_agent_parser
 
 def main(request, response):
-    # First get the browser from the UA string
-
     ua_string = request.headers.get("User-Agent").decode("utf-8");
-    ua = user_agent_parser.ParseUserAgent(ua_string)
-    ua_family = ua["family"];
-
-    root = acacia_atspi.findRootAtspiNodeForName(ua_family)
-
+    root = find_browser(ua_string)
     if root.isNull():
       print("Cannot find root accessibility node for %s - did you turn on accessibility?"
             % ua_family);
-      return (200, 'could not find %s' % ua_family), [('Content-Type', 'foo/bar')], 'no data'
-    test_url = request.GET[b'test_url'].decode('UTF-8')
-    tab = find_tab(root, test_url)
+      return (200, 'could not find %s' % ua_family), [('Content-Type', 'foo/bar')], '{"error": "no data"}'
+
+    test_title = request.GET[b'title'].decode('UTF-8')
+    tab = find_tab(root, test_title)
     if not tab:
-      print('Cannot find document for %s'
-            % test_url);
-      return (200, 'could not find %s' % test_url), [('Content-Type', 'foo/bar')], 'no data'
+      print('Cannot find tab for %s'
+            % test_title);
+      return (200, 'could not find %s' % test_title), [('Content-Type', 'foo/bar')], '{"error": "no data"}'
 
     test_id = request.GET[b'id'].decode('UTF-8')
     node = find_node(tab, test_id)
     if not node:
         print('Cannot find node for %s' % test_id)
-        return (200, 'could not find %s' % test_id), [('Content-Type', 'foo/bar')], 'no data'
+        return (200, 'could not find %s' % test_id), [('Content-Type', 'foo/bar')], '{"error": "no data"}'
 
-    node_dictionary = {}
-    node_dictionary['role'] = node.getRoleName()
-    node_dictionary['name'] = node.getName()
-    node_dictionary['description'] = node.getDescription()
-    node_dictionary['states'] = sorted(node.getStates())
-    node_dictionary['interfaces'] = sorted(node.getInterfaces())
-    node_dictionary['attributes'] = sorted(node.getAttributes())
+    node_dictionary = serialize_node(node);
 
     return ((200, 'Found'), [('Content-Type', 'text/json')], json.dumps(node_dictionary))
 
-def find_tab(root, test_url):
+def find_browser(ua_string):
+    ua = user_agent_parser.ParseUserAgent(ua_string)
+    ua_family = ua["family"];
+
+    print("family: " + ua_family)
+
+    if (ua_family == "HeadlessChrome"):
+        ua_family = "chrome"
+
+    # TODO: Is there any other way to get the browser name or PID before this point?
+    return acacia_atspi.findRootAtspiNodeForName(ua_family)
+
+
+def find_tab(root, test_title):
     stack = [root]
     while stack:
         node = stack.pop()
 
+        print("right about to get the role name......")
         if node.getRoleName() == 'document web':
-            document = node.queryDocument()
-            if document.isNull():
-                continue
-            attributes = document.getDocumentAttributes()
-            for attribute_pair in attributes:
-                [attribute, value] = attribute_pair.split(':', 1)
-                if attribute == 'DocURL':
-                    if value == test_url:
-                        return node
+            if (node.getName() == test_title):
+                return node
             # Don't continue traversing into documents
             continue
 
@@ -80,3 +76,16 @@ def find_node(tab, test_id):
             stack.append(child)
 
     return None
+
+def serialize_node(node):
+    node_dictionary = {}
+    node_dictionary['role'] = node.getRoleName()
+    node_dictionary['name'] = node.getName()
+    node_dictionary['description'] = node.getDescription()
+    node_dictionary['states'] = sorted(node.getStates())
+    node_dictionary['interfaces'] = sorted(node.getInterfaces())
+    node_dictionary['attributes'] = sorted(node.getAttributes())
+
+    # TODO: serialize other attributes
+
+    return node_dictionary

--- a/core-aam/acacia/resources/acacia.py
+++ b/core-aam/acacia/resources/acacia.py
@@ -1,0 +1,21 @@
+import acacia_atspi
+from ua_parser import user_agent_parser
+
+def main(request, response):
+
+    # First get the browser from the UA string
+
+    ua_string = request.headers.get("User-Agent").decode("utf-8");
+    ua = user_agent_parser.ParseUserAgent(ua_string)
+    ua_family = ua["family"];
+
+    print("Searching for browser with name %s" % ua_family)
+    root = acacia_atspi.findRootAtspiNodeForName(ua_family)
+
+    if root.isNull():
+      print("Cannot find root accessibility node for %s - did you turn on accessibility?"
+            % ua_family);
+      return (200, 'could not find %s' % ua_family), [('Content-Type', 'foo/bar')], 'no data'
+
+    print("Found!!");
+    return (200, 'Found'), [('Content-Type', 'foo/bar')], 'test data'

--- a/core-aam/acacia/resources/acacia.py
+++ b/core-aam/acacia/resources/acacia.py
@@ -1,21 +1,82 @@
 import acacia_atspi
+import json
 from ua_parser import user_agent_parser
 
 def main(request, response):
-
     # First get the browser from the UA string
 
     ua_string = request.headers.get("User-Agent").decode("utf-8");
     ua = user_agent_parser.ParseUserAgent(ua_string)
     ua_family = ua["family"];
 
-    print("Searching for browser with name %s" % ua_family)
     root = acacia_atspi.findRootAtspiNodeForName(ua_family)
 
     if root.isNull():
       print("Cannot find root accessibility node for %s - did you turn on accessibility?"
             % ua_family);
       return (200, 'could not find %s' % ua_family), [('Content-Type', 'foo/bar')], 'no data'
+    test_url = request.GET[b'test_url'].decode('UTF-8')
+    tab = find_tab(root, test_url)
+    if not tab:
+      print('Cannot find document for %s'
+            % test_url);
+      return (200, 'could not find %s' % test_url), [('Content-Type', 'foo/bar')], 'no data'
 
-    print("Found!!");
-    return (200, 'Found'), [('Content-Type', 'foo/bar')], 'test data'
+    test_id = request.GET[b'id'].decode('UTF-8')
+    node = find_node(tab, test_id)
+    if not node:
+        print('Cannot find node for %s' % test_id)
+        return (200, 'could not find %s' % test_id), [('Content-Type', 'foo/bar')], 'no data'
+
+    node_dictionary = {}
+    node_dictionary['role'] = node.getRoleName()
+    node_dictionary['name'] = node.getName()
+    node_dictionary['description'] = node.getDescription()
+    node_dictionary['states'] = sorted(node.getStates())
+    node_dictionary['interfaces'] = sorted(node.getInterfaces())
+    node_dictionary['attributes'] = sorted(node.getAttributes())
+
+    return ((200, 'Found'), [('Content-Type', 'text/json')], json.dumps(node_dictionary))
+
+def find_tab(root, test_url):
+    stack = [root]
+    while stack:
+        node = stack.pop()
+
+        if node.getRoleName() == 'document web':
+            document = node.queryDocument()
+            if document.isNull():
+                continue
+            attributes = document.getDocumentAttributes()
+            for attribute_pair in attributes:
+                [attribute, value] = attribute_pair.split(':', 1)
+                if attribute == 'DocURL':
+                    if value == test_url:
+                        return node
+            # Don't continue traversing into documents
+            continue
+
+        for i in range(node.getChildCount()):
+            child = node.getChildAtIndex(i)
+            stack.append(child)
+
+    return None
+
+
+def find_node(tab, test_id):
+    stack = [tab]
+    while stack:
+        node = stack.pop()
+
+        attributes = node.getAttributes()
+        for attribute_pair in attributes:
+            [attribute, value] = attribute_pair.split(':', 1)
+            if attribute == 'id':
+                if value == test_id:
+                    return node
+
+        for i in range(node.getChildCount()):
+            child = node.getChildAtIndex(i)
+            stack.append(child)
+
+    return None

--- a/core-aam/acacia/test.html
+++ b/core-aam/acacia/test.html
@@ -9,12 +9,12 @@
   <script>
     promise_test(async () => {
       const params = {
-          test_url: window.location.href,
+          title: document.title,
           id: 'test',
       };
       const url = 'resources/acacia.py?' + new URLSearchParams(params);
       console.log({url});
-      const response = await fetch(url);
+      const reponse = await fetch(url);
       console.log({response});
       const node = await response.json();
       console.log({node});

--- a/core-aam/acacia/test.html
+++ b/core-aam/acacia/test.html
@@ -14,7 +14,7 @@
       };
       const url = 'resources/acacia.py?' + new URLSearchParams(params);
       console.log({url});
-      const reponse = await fetch(url);
+      const response = await fetch(url);
       console.log({response});
       const node = await response.json();
       console.log({node});

--- a/core-aam/acacia/test.html
+++ b/core-aam/acacia/test.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>core-aam: first acacia test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <div id=test role="button"></div>
+  <script>
+    promise_test(function() {
+      return fetch('resources/acacia.py')
+        .then(function(response) {
+            // reponse.body?
+            assert_equals(response.statusText, 'Found');
+          });
+    }, "An acacia test!");
+  </script>
+</body>

--- a/core-aam/acacia/test.html
+++ b/core-aam/acacia/test.html
@@ -3,15 +3,23 @@
 <title>core-aam: first acacia test</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+
 <body>
   <div id=test role="button"></div>
   <script>
-    promise_test(function() {
-      return fetch('resources/acacia.py')
-        .then(function(response) {
-            // reponse.body?
-            assert_equals(response.statusText, 'Found');
-          });
+    promise_test(async () => {
+      const params = {
+          test_url: window.location.href,
+          id: 'test',
+      };
+      const url = 'resources/acacia.py?' + new URLSearchParams(params);
+      console.log({url});
+      const response = await fetch(url);
+      console.log({response});
+      const node = await response.json();
+      console.log({node});
+      assert_equals(response.statusText, 'Found');
+      assert_equals(node.role, 'push button');
     }, "An acacia test!");
   </script>
 </body>

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -519,6 +519,8 @@ class Chrome(BrowserSetup):
             # We are on Taskcluster, where our Docker container does not have
             # enough capabilities to run Chrome with sandboxing. (gh-20133)
             kwargs["binary_args"].append("--no-sandbox")
+        if kwargs["force_renderer_accessibility"]:
+            kwargs["binary_args"].append("--force-renderer-accessibility")
 
 
 class ContentShell(BrowserSetup):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -377,6 +377,9 @@ scheme host and port.""")
     chrome_group.add_argument("--no-enable-experimental", action="store_false", dest="enable_experimental",
                               help="Do not enable --enable-experimental-web-platform-features flag "
                               "on experimental channels")
+    chrome_group.add_argument("--force-renderer-accessibility", action="store_true", dest="force_renderer_accessibility",
+                              help="Turn on accessibility.")
+
     chrome_group.add_argument(
         "--enable-sanitizer",
         action="store_true",


### PR DESCRIPTION
This experiment currently only runs on linux -- works for both chrome and firefox, but not "chromium". The browser is derived from the UA string, and the UA string doesn't differentiate between chrome and chromium.

To run the test:
1. Install the acacia library
2. (for debian) install python3-ua-parser (or pip install ua-parser)
3. run a wpt server with `./wpt serve` ([see WPT docs](https://web-platform-tests.org/running-tests/from-local-system.html))
4. navigate to `http://web-platform.test:8000/core-aam/acacia/test.html`

or run:
```
./wpt run --force-renderer-accessibility chrome /core-aam/acacia/test.html
./wpt run --force-renderer-accessibility firefox /core-aam/acacia/test.html
```