### PR TITLE
Switch to gi Atspi, and work on waiting for `document:load-complete`

### DIFF
--- a/core-aam/acacia/test-testdriver.html
+++ b/core-aam/acacia/test-testdriver.html
@@ -9,10 +9,17 @@
 
 <body>
   <div id=testtest role="button"></div>
+
   <script>
     promise_test(async t => {
       const node = await test_driver.get_accessibility_api_node('testtest');
       assert_equals(node.role, 'push button');
-    }, 'An acacia test');
+    }, 'An acacia test 1');
+
+    // This second test is helping me find a race condition right now!
+    promise_test(async t => {
+      const node = await test_driver.get_accessibility_api_node('testtest');
+      assert_equals(node.role, 'push button');
+    }, 'An acacia test 2');
   </script>
 </body>

--- a/tools/wptrunner/wptrunner/executors/executoracacia.py
+++ b/tools/wptrunner/wptrunner/executors/executoracacia.py
@@ -1,117 +1,27 @@
-import gi
-gi.require_version("Atspi", "2.0")
-from gi.repository import Atspi
-import json
-import threading
 from .protocol import (PlatformAccessibilityProtocolPart)
 
-
-import traceback
-import time
-
-
-def find_active_tab(root):
-    stack = [root]
-    while stack:
-        node = stack.pop()
-
-        if Atspi.Accessible.get_role_name(node) == 'frame':
-            ## Helper: list of string relations, get targets for relation?
-            relationset = Atspi.Accessible.get_relation_set(node)
-            for relation in relationset:
-              if relation.get_relation_type() == Atspi.RelationType.EMBEDS:
-                  return relation.get_target(0)
-            contiue
-
-        for i in range(Atspi.Accessible.get_child_count(node)):
-            child = Atspi.Accessible.get_child_at_index(node, i)
-            stack.append(child)
-
-    return None
-
-def serialize_node(node):
-    node_dictionary = {}
-    node_dictionary['role'] = Atspi.Accessible.get_role_name(node)
-    node_dictionary['name'] = Atspi.Accessible.get_name(node)
-    node_dictionary['description'] = Atspi.Accessible.get_description(node)
-
-    # TODO: serialize other attributes
-    # states, interfaces, attributes, etc.
-
-    return node_dictionary
-
-def find_node(root, dom_id):
-    stack = [root]
-    while stack:
-        node = stack.pop()
-
-        attributes = Atspi.Accessible.get_attributes(node)
-        if 'id' in attributes and attributes['id'] == dom_id:
-            return node
-
-        for i in range(Atspi.Accessible.get_child_count(node)):
-            child = Atspi.Accessible.get_child_at_index(node, i)
-            stack.append(child)
-
-    return None
-
-def find_browser(name):
-    desktop = Atspi.get_desktop(0)
-    child_count = Atspi.Accessible.get_child_count(desktop)
-    for i in range(child_count):
-        app = Atspi.Accessible.get_child_at_index(desktop, i)
-        full_app_name = Atspi.Accessible.get_name(app)
-        if name in full_app_name.lower():
-            return (app, full_app_name)
-    return
+from sys import platform
+linux = False
+mac = False
+if platform == "linux":
+  linux = True
+  from .executoratspi import *
+if platform == "darwin":
+  mac = True
+  from .executoraxapi import *
 
 
 class AcaciaPlatformAccessibilityProtocolPart(PlatformAccessibilityProtocolPart):
-    def start_atspi_listener(self):
-        self._event_listener = Atspi.EventListener.new(self.handle_event)
-        self._event_listener.register("document:load-complete")
-        Atspi.event_main()
-
-
-    def handle_event(self, e):
-        app = Atspi.Accessible.get_application(e.source)
-        app_name = Atspi.Accessible.get_name(app)
-        if (self.full_app_name == app_name and e.any_data):
-            self.load_complete = True
-            self._event_listener.deregister("document:load-complete")
-            Atspi.event_quit()
-
     def setup(self):
         self.product_name = self.parent.product_name
-        self.full_app_name = ''
-        self.root = None
-        self.found_browser = False
-        self.load_complete = False
+        self.impl = None
+        if linux:
+            self.impl = AtspiExecutorImpl()
+            self.impl.setup(self.product_name)
+        if mac:
+            self.impl = AXAPIExecutorImpl()
+            self.impl.setup(self.product_name)
 
-        self.atspi_listener_thread = threading.Thread(target=self.start_atspi_listener)
-
-        (self.root, self.full_app_name) = find_browser(self.product_name);
-        if self.root:
-            self.found_browser = True
-            self.atspi_listener_thread.start()
-        else:
-            print(f"Cannot find root accessibility node for {self.product_name} - did you turn on accessibility?")
 
     def get_accessibility_api_node(self, dom_id):
-        if not self.load_complete:
-          self.atspi_listener_thread.join()
-
-        if not self.found_browser:
-            return json.dumps({"role": "couldn't find browser"})
-
-        active_tab = find_active_tab(self.root)
-        if not active_tab:
-            return json.dumps({"role": "couldn't find active tab"})
-
-        node = find_node(active_tab, dom_id)
-        if not node:
-            return json.dumps({"role": "couldn't find the node with that ID"})
-
-        return json.dumps(serialize_node(node))
-
-
+      return self.impl.get_accessibility_api_node(dom_id)

--- a/tools/wptrunner/wptrunner/executors/executoracacia.py
+++ b/tools/wptrunner/wptrunner/executors/executoracacia.py
@@ -2,7 +2,13 @@ import gi
 gi.require_version("Atspi", "2.0")
 from gi.repository import Atspi
 import json
+import threading
 from .protocol import (PlatformAccessibilityProtocolPart)
+
+
+import traceback
+import time
+
 
 def find_active_tab(root):
     stack = [root]
@@ -54,40 +60,53 @@ def find_browser(name):
     child_count = Atspi.Accessible.get_child_count(desktop)
     for i in range(child_count):
         app = Atspi.Accessible.get_child_at_index(desktop, i)
-        if name in Atspi.Accessible.get_name(app).lower():
-            return app
+        full_app_name = Atspi.Accessible.get_name(app)
+        if name in full_app_name.lower():
+            return (app, full_app_name)
     return
 
 
-
 class AcaciaPlatformAccessibilityProtocolPart(PlatformAccessibilityProtocolPart):
+    def start_atspi_listener(self):
+        self._event_listener = Atspi.EventListener.new(self.handle_event)
+        self._event_listener.register("document:load-complete")
+        Atspi.event_main()
+
+
     def handle_event(self, e):
-        print(f"---------------- EVENT ----------------")
-        print(f"{e.type}")
+        app = Atspi.Accessible.get_application(e.source)
+        app_name = Atspi.Accessible.get_name(app)
+        if (self.full_app_name == app_name and e.any_data):
+            self.load_complete = True
+            self._event_listener.deregister("document:load-complete")
+            Atspi.event_quit()
 
     def setup(self):
         self.product_name = self.parent.product_name
+        self.full_app_name = ''
         self.root = None
         self.found_browser = False
+        self.load_complete = False
 
-        print(f"---------------- LISTENING ----------------")
-        self._event_listener = Atspi.EventListener.new(self.handle_event)
-        self._event_listener.register("document:load-complete")
+        self.atspi_listener_thread = threading.Thread(target=self.start_atspi_listener)
 
-        self.root = find_browser(self.product_name);
+        (self.root, self.full_app_name) = find_browser(self.product_name);
         if self.root:
             self.found_browser = True
+            self.atspi_listener_thread.start()
         else:
             print(f"Cannot find root accessibility node for {self.product_name} - did you turn on accessibility?")
 
     def get_accessibility_api_node(self, dom_id):
+        if not self.load_complete:
+          self.atspi_listener_thread.join()
+
         if not self.found_browser:
             return json.dumps({"role": "couldn't find browser"})
 
         active_tab = find_active_tab(self.root)
         if not active_tab:
             return json.dumps({"role": "couldn't find active tab"})
-
 
         node = find_node(active_tab, dom_id)
         if not node:

--- a/tools/wptrunner/wptrunner/executors/executoratspi.py
+++ b/tools/wptrunner/wptrunner/executors/executoratspi.py
@@ -66,7 +66,7 @@ def find_browser(name):
     return
 
 
-class AtspiSupport():
+class AtspiExecutorImpl():
     def start_atspi_listener(self):
         self._event_listener = Atspi.EventListener.new(self.handle_event)
         self._event_listener.register("document:load-complete")

--- a/tools/wptrunner/wptrunner/executors/executoratspi.py
+++ b/tools/wptrunner/wptrunner/executors/executoratspi.py
@@ -1,0 +1,117 @@
+import gi
+gi.require_version("Atspi", "2.0")
+from gi.repository import Atspi
+import json
+import threading
+from .protocol import (PlatformAccessibilityProtocolPart)
+
+
+import traceback
+import time
+
+
+def find_active_tab(root):
+    stack = [root]
+    while stack:
+        node = stack.pop()
+
+        if Atspi.Accessible.get_role_name(node) == 'frame':
+            ## Helper: list of string relations, get targets for relation?
+            relationset = Atspi.Accessible.get_relation_set(node)
+            for relation in relationset:
+              if relation.get_relation_type() == Atspi.RelationType.EMBEDS:
+                  return relation.get_target(0)
+            contiue
+
+        for i in range(Atspi.Accessible.get_child_count(node)):
+            child = Atspi.Accessible.get_child_at_index(node, i)
+            stack.append(child)
+
+    return None
+
+def serialize_node(node):
+    node_dictionary = {}
+    node_dictionary['role'] = Atspi.Accessible.get_role_name(node)
+    node_dictionary['name'] = Atspi.Accessible.get_name(node)
+    node_dictionary['description'] = Atspi.Accessible.get_description(node)
+
+    # TODO: serialize other attributes
+    # states, interfaces, attributes, etc.
+
+    return node_dictionary
+
+def find_node(root, dom_id):
+    stack = [root]
+    while stack:
+        node = stack.pop()
+
+        attributes = Atspi.Accessible.get_attributes(node)
+        if 'id' in attributes and attributes['id'] == dom_id:
+            return node
+
+        for i in range(Atspi.Accessible.get_child_count(node)):
+            child = Atspi.Accessible.get_child_at_index(node, i)
+            stack.append(child)
+
+    return None
+
+def find_browser(name):
+    desktop = Atspi.get_desktop(0)
+    child_count = Atspi.Accessible.get_child_count(desktop)
+    for i in range(child_count):
+        app = Atspi.Accessible.get_child_at_index(desktop, i)
+        full_app_name = Atspi.Accessible.get_name(app)
+        if name in full_app_name.lower():
+            return (app, full_app_name)
+    return
+
+
+class AtspiSupport():
+    def start_atspi_listener(self):
+        self._event_listener = Atspi.EventListener.new(self.handle_event)
+        self._event_listener.register("document:load-complete")
+        Atspi.event_main()
+
+
+    def handle_event(self, e):
+        app = Atspi.Accessible.get_application(e.source)
+        app_name = Atspi.Accessible.get_name(app)
+        if (self.full_app_name == app_name and e.any_data):
+            self.load_complete = True
+            self._event_listener.deregister("document:load-complete")
+            Atspi.event_quit()
+
+    def setup(self, product_name):
+        self.product_name = product_name
+        self.full_app_name = ''
+        self.root = None
+        self.found_browser = False
+        self.load_complete = False
+
+        self.atspi_listener_thread = threading.Thread(target=self.start_atspi_listener)
+
+        (self.root, self.full_app_name) = find_browser(self.product_name);
+        if self.root:
+            self.found_browser = True
+            self.atspi_listener_thread.start()
+        else:
+            print(f"Cannot find root accessibility node for {self.product_name} - did you turn on accessibility?")
+
+    def get_accessibility_api_node(self, dom_id):
+        if not self.load_complete:
+          self.atspi_listener_thread.join()
+
+        if not self.found_browser:
+            return json.dumps({"role": "couldn't find browser"})
+
+        active_tab = find_active_tab(self.root)
+        if not active_tab:
+            return json.dumps({"role": "couldn't find active tab"})
+
+        node = find_node(active_tab, dom_id)
+        if not node:
+            return json.dumps({"role": "couldn't find the node with that ID"})
+
+        return json.dumps(serialize_node(node))
+
+

--- a/tools/wptrunner/wptrunner/executors/executoratspi.py
+++ b/tools/wptrunner/wptrunner/executors/executoratspi.py
@@ -63,7 +63,7 @@ def find_browser(name):
         full_app_name = Atspi.Accessible.get_name(app)
         if name in full_app_name.lower():
             return (app, full_app_name)
-    return
+    return (None, None)
 
 
 class AtspiExecutorImpl():
@@ -98,11 +98,11 @@ class AtspiExecutorImpl():
             print(f"Cannot find root accessibility node for {self.product_name} - did you turn on accessibility?")
 
     def get_accessibility_api_node(self, dom_id):
-        if not self.load_complete:
-          self.atspi_listener_thread.join()
-
         if not self.found_browser:
             return json.dumps({"role": "couldn't find browser"})
+
+        if not self.load_complete:
+          self.atspi_listener_thread.join()
 
         active_tab = find_active_tab(self.root)
         if not active_tab:

--- a/tools/wptrunner/wptrunner/executors/executoraxapi.py
+++ b/tools/wptrunner/wptrunner/executors/executoraxapi.py
@@ -1,0 +1,36 @@
+from ApplicationServices import (
+    AXUIElementRef,
+    AXUIElementCopyAttributeNames,
+    AXUIElementCopyAttributeValue,
+    AXUIElementCopyParameterizedAttributeValue,
+    AXUIElementCopyParameterizedAttributeNames,
+    AXUIElementIsAttributeSettable,
+    AXUIElementCopyActionNames,
+    AXUIElementSetAttributeValue,
+    AXUIElementCreateApplication,
+    AXUIElementCopyMultipleAttributeValues,
+    AXUIElementCopyActionDescription,
+    AXValueRef,
+    AXValueGetType,
+    kAXValueAXErrorType,
+)
+
+class AXAPIExecutorImpl:
+    def setup(self, product_name):
+        self.product_name = product_name
+
+    def get_application_by_name(self, name):
+        # TODO: copied directly from https://github.com/eeejay/pyax/blob/main/src/pyax/_uielement.py
+        wl = CGWindowListCopyWindowInfo(
+            kCGWindowListExcludeDesktopElements, kCGNullWindowID
+        )
+        for w in wl:
+            n = w.valueForKey_("kCGWindowOwnerName")
+            if name == w.valueForKey_("kCGWindowOwnerName"):
+                return AXUIElementCreateApplication(
+                    int((w.valueForKey_("kCGWindowOwnerPID")))
+                )
+
+    def get_accessibility_api_node(self, dom_id):
+        app = self.get_application_by_name(self.product_name)
+

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -494,7 +494,7 @@ class TestRunnerManager(threading.Thread):
         }
         try:
             command, data = self.command_queue.get(True, 1)
-            self.logger.debug("Got command: %r" % command)
+            #self.logger.debug("Got command: %r" % command)
         except OSError:
             self.logger.error("Got IOError from poll")
             return RunnerManagerState.restarting(self.state.subsuite,


### PR DESCRIPTION
So the diff here is a hard to look at, but here is the file on the branch: https://github.com/Igalia/wpt/blob/a53e36e604db76a6166626c418903d4eef4f631c/tools/wptrunner/wptrunner/executors/executoracacia.py

Eventually, we will have to handle multiple tests execute in row, we will have to wait for the new test page to be loaded as well. To do this we need to know the title of the test page, which might mean some more data plumbing from the test harness to this part of execution logic.