### PR TITLE
Experiment with a different test file design, single file with all mappings

### DIFF
--- a/core-aam/json-test-example/aria-autocomplete.html
+++ b/core-aam/json-test-example/aria-autocomplete.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>aria-braillelabel</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/attr-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<input role='combobox' id='test1' aria-autocomplete='both'>
+<input role='combobox' id='test2' aria-autocomplete='inline'>
+<input role='combobox' id='test3' aria-autocomplete='list'>
+
+<script>
+  AAMUtils.verifyAttrAPI(
+    'test1',
+    'both',
+    attrmap['aria-autocomplete'],
+    'aria-autocomplete=both'
+  );
+
+  AAMUtils.verifyAttrAPI(
+    'test2',
+    'inline',
+    attrmap['aria-autocomplete'],
+    'aria-autocomplete=inline'
+  );
+
+  AAMUtils.verifyAttrAPI(
+    'test3',
+    'list',
+    attrmap['aria-autocomplete'],
+    'aria-autocomplete=list'
+  );
+
+</script>
+
+</body>
+</html>

--- a/core-aam/json-test-example/aria-braillelabel.html
+++ b/core-aam/json-test-example/aria-braillelabel.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>aria-braillelabel</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/attr-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<button id=test aria-braillelabel=foobar>
+
+<script>
+  AAMUtils.verifyAttrAPI(
+    'test',
+    'foobar',
+    attrmap['aria-braillelabel'],
+    'aria-braillelabel'
+  );
+</script>
+
+</body>
+</html>

--- a/core-aam/json-test-example/aria-errormessage.html
+++ b/core-aam/json-test-example/aria-errormessage.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>aria-flowto</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/attr-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<div role='checkbox' id='test' aria-errormessage='error1 error2' aria-invalid='true'>content</div>
+<div id='error1'>hello</div>
+<div id='error2'>world</div>
+
+<script>
+  AAMUtils.verifyRelationAPI(
+    'test',
+    ['error1', 'error2'],
+    attrmap['aria-errormessage'],
+    'aria-flowto'
+  );
+</script>
+
+</body>
+</html>

--- a/core-aam/json-test-example/blockquote.html
+++ b/core-aam/json-test-example/blockquote.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>role blockquote</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/role-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<div id=test role=blockquote>quote</div>
+
+<script>
+  AAMUtils.verifyAPI('test', rolemap['blockquote'], 'role=blockquote');
+</script>
+
+</body>
+</html>

--- a/core-aam/json-test-example/button_with_default_values_for_aria-pressed_and_aria-haspopup.html
+++ b/core-aam/json-test-example/button_with_default_values_for_aria-pressed_and_aria-haspopup.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>role button with default values for aria-pressed and aria-hapopup</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/role-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<div id=test1 role=button>click me</div>
+<div id=test2 role=button aria-pressed>click me</div>
+<div id=test3 role=button aria-pressed aria-haspopup>click me</div>
+<div id=test4 role=button aria-haspopup>click me</div>
+<div id=test5 role=button aria-haspopup=false>click me</div>
+
+<script>
+  AAMUtils.verifyAPI(
+    'test1',
+    rolemap['button_with_default_values_for_aria-pressed_and_aria-haspopup'],
+    'role=button'
+  );
+
+  AAMUtils.verifyAPI(
+    'test2',
+    rolemap['button_with_default_values_for_aria-pressed_and_aria-haspopup'],
+    'role=button aria-pressed'
+  );
+
+  AAMUtils.verifyAPI(
+    'test3',
+    rolemap['button_with_default_values_for_aria-pressed_and_aria-haspopup'],
+    'role=button aria-pressed aria-haspopup'
+  );
+
+  AAMUtils.verifyAPI(
+    'test4',
+    rolemap['button_with_default_values_for_aria-pressed_and_aria-haspopup'],
+    'role=button aria-haspopup'
+  );
+
+  AAMUtils.verifyAPI(
+    'test5',
+    rolemap['button_with_default_values_for_aria-pressed_and_aria-haspopup'],
+    'role=button aria-haspopup=false'
+  );
+</script>
+
+</body>
+</html>

--- a/core-aam/json-test-example/button_with_defined_value_for_aria-pressed.html
+++ b/core-aam/json-test-example/button_with_defined_value_for_aria-pressed.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>role button with defined value for aria-pressed</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/role-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<div id=test1 role=button aria-pressed=true>press me</div>
+<div id=test2 role=button aria-pressed=false>press me</div>
+
+<script>
+  AAMUtils.verifyAPI(
+    'test1',
+    rolemap['button_with_defined_value_for_aria-pressed'],
+    'role=button aria-pressed=true'
+  );
+
+  AAMUtils.verifyAPI(
+    'test2',
+    rolemap['button_with_defined_value_for_aria-pressed'],
+    'role=button aria-pressed=false'
+  );
+</script>
+</body>

--- a/core-aam/json-test-example/button_with_non_false_value_for_aria-haspopup.html
+++ b/core-aam/json-test-example/button_with_non_false_value_for_aria-haspopup.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+<head>
+  <title>role button with non false value for aria-pressed</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="scripts/role-map.js"></script>
+  <script src="scripts/aam-utils.js"></script>
+</head>
+<body>
+
+<div id=test1 role=button aria-haspopup=true>click me</div>
+<div id=test2 role=button aria-haspopup=menu>click me</div>
+<div id=test3 role=button aria-haspopup=listbox>click me</div>
+<div id=test4 role=button aria-haspopup=tree>click me</div>
+<div id=test5 role=button aria-haspopup=grid>click me</div>
+<div id=test6 role=button aria-haspopup=dialog>click me</div>
+
+<script>
+
+  AAMUtils.verifyAPI(
+    'test1',
+    rolemap['button_with_non_false_value_for_aria-haspopup'],
+    'role=button aria-haspopup=true'
+  );
+
+  AAMUtils.verifyAPI(
+    'test2',
+    rolemap['button_with_non_false_value_for_aria-haspopup'],
+    'role=button aria-haspopup=menu'
+  );
+
+  AAMUtils.verifyAPI(
+    'test3',
+    rolemap['button_with_non_false_value_for_aria-haspopup'],
+    'role=button aria-haspopup=listbox'
+  );
+
+  AAMUtils.verifyAPI(
+    'test4',
+    rolemap['button_with_non_false_value_for_aria-haspopup'],
+    'role=button aria-haspopup=tree'
+  );
+
+  AAMUtils.verifyAPI(
+    'test5',
+    rolemap['button_with_non_false_value_for_aria-haspopup'],
+    'role=button aria-haspopup=grid'
+  );
+
+  AAMUtils.verifyAPI(
+    'test6',
+    rolemap['button_with_non_false_value_for_aria-haspopup'],
+    'role=button aria-haspopup=dialog'
+  );
+
+</script>
+</body>

--- a/core-aam/json-test-example/scripts/aam-utils.js
+++ b/core-aam/json-test-example/scripts/aam-utils.js
@@ -4,8 +4,23 @@
 */
 
 const AAMUtils = {
-
   APIS: ['Atspi', 'AXAPI', 'IAccessible2', 'UIA'],
+
+  runAssertions: function(test_statements, results) {
+    // If the test was not run, the API doesn't apply to backend OS,
+    // pass with no asserts.
+    if (!results) {
+      return;
+    }
+
+    if (results.length !== test_statements.length)
+      assert_unreached(`Recieved a different number of results than test statements: ${results}`)
+
+    for (i = 0; i < results.length; i++) {
+      assert_equals(results[i], "Pass", `${test_statements[i].join(' ')}`)
+    }
+  },
+
 
   /*
     Creates a subtest for each API. Runs no asserts for APIs not found.
@@ -21,16 +36,16 @@ const AAMUtils = {
     }
 
     for (const api of this.APIS) {
-      if (map[api]) {
+      if (map[api] && map[api].length) {
         promise_test(async t => {
-          let result = await test_driver.test_accessibility_api(
+          let results = await test_driver.test_accessibility_api(
             id,
             map,
             api
           );
-          if (result) {
-            assert_equals(result, "match");
-          }
+
+          this.runAssertions(map[api], results);
+
         }, `api: ${api}, ${test_name}`);
       }
     }
@@ -58,14 +73,14 @@ const AAMUtils = {
     for (const api of this.APIS) {
       if (new_map[api]) {
         promise_test(async t => {
-          let result = await test_driver.test_accessibility_api(
+          let results = await test_driver.test_accessibility_api(
             id,
             new_map,
             api
           );
-          if (result) {
-            assert_equals(result, "match");
-          }
+
+          this.runAssertions(new_map[api], results);
+
         }, `api: ${api}, ${test_name}`);
       }
     }
@@ -92,14 +107,14 @@ const AAMUtils = {
     for (const api of this.APIS) {
       if (new_map[api]) {
         promise_test(async t => {
-          let result = await test_driver.test_accessibility_api(
+          let results = await test_driver.test_accessibility_api(
             id,
             new_map,
             api
           );
-          if (result) {
-            assert_equals(result, "match");
-          }
+
+          this.runAssertions(new_map[api], results);
+
         }, `api: ${api}, ${test_name}`);
       }
     }

--- a/core-aam/json-test-example/scripts/aam-utils.js
+++ b/core-aam/json-test-example/scripts/aam-utils.js
@@ -1,0 +1,107 @@
+/*
+  Utility files for platform specific accessibility API tests for the
+  Accessibility API Mappings (AAM) standards: Core-AAM and HTML-aam
+*/
+
+const AAMUtils = {
+
+  APIS: ['Atspi', 'AXAPI', 'IAccessible2', 'UIA'],
+
+  /*
+    Creates a subtest for each API. Runs no asserts for APIs not found.
+
+    id:     id of element to test the accessibility node of
+    map:    entry in role-map.js, or similar
+    name:   name of the test
+  */
+
+  verifyAPI: function(id, map, test_name) {
+    if (!map) {
+      throw "Error: missing accessibility API test map";
+    }
+
+    for (const api of this.APIS) {
+      if (map[api]) {
+        promise_test(async t => {
+          let result = await test_driver.test_accessibility_api(
+            id,
+            map,
+            api
+          );
+          if (result) {
+            assert_equals(result, "match");
+          }
+        }, `api: ${api}, ${test_name}`);
+      }
+    }
+  },
+
+  /*
+    Creates a subtest for each API. Runs no asserts for APIs not found.
+
+    id:         id of element to test the accessibility node of
+    value:      value of the attribute being tested
+    map:        entry in attr-map.js, or similar, with the string "<value>"
+                to be replaced by the value argument
+    test_name:  name of the test
+  */
+
+  verifyAttrAPI: function(id, value, map, test_name) {
+    if (!map) {
+      throw "Error: missing accessibility API test map";
+    }
+
+    let new_map = JSON.parse(
+      JSON.stringify(map).replaceAll("<value>", value)
+    );
+
+    for (const api of this.APIS) {
+      if (new_map[api]) {
+        promise_test(async t => {
+          let result = await test_driver.test_accessibility_api(
+            id,
+            new_map,
+            api
+          );
+          if (result) {
+            assert_equals(result, "match");
+          }
+        }, `api: ${api}, ${test_name}`);
+      }
+    }
+  },
+
+  /*
+    Creates a subtest for each API. Runs no asserts for APIs not found.
+
+    id:         id of element to test the accessibility node of
+    relations:  list of ids of "related" elements
+    map:        entry in attr-map.js, or similar
+    test_name:  name of the test
+  */
+
+  verifyRelationAPI: function(id, relations, map, test_name) {
+    if (!map) {
+      throw "Error: missing accessibility API test map";
+    }
+
+    let new_map = JSON.parse(
+      JSON.stringify(map).replaceAll("\"<id-list>\"", JSON.stringify(relations))
+    );
+
+    for (const api of this.APIS) {
+      if (new_map[api]) {
+        promise_test(async t => {
+          let result = await test_driver.test_accessibility_api(
+            id,
+            new_map,
+            api
+          );
+          if (result) {
+            assert_equals(result, "match");
+          }
+        }, `api: ${api}, ${test_name}`);
+      }
+    }
+  }
+}

--- a/core-aam/json-test-example/scripts/attr-map.js
+++ b/core-aam/json-test-example/scripts/attr-map.js
@@ -1,0 +1,114 @@
+attrmap = {
+  "aria-autocomplete": {
+    "Atspi" : [
+       [
+          "property",
+          "objectAttributes",
+          "contains",
+          "autocomplete:<value>"
+       ],
+       [
+          "property",
+          "states",
+          "contains",
+          "STATE_SUPPORTS_AUTOCOMPLETION"
+       ]
+    ],
+    "IAccessible2" : [
+       [
+          "property",
+          "objectAttributes",
+          "contains",
+          "autocomplete:<value>"
+       ],
+       [
+          "property",
+          "states",
+          "contains",
+          "IA2_STATE_SUPPORTS_AUTOCOMPLETION"
+       ]
+    ]
+  },
+  "aria-braillelabel": {
+    "Atspi" : [
+       [
+          "property",
+          "objectAttributes",
+          "contains",
+          "braillelabel:<value>"
+       ]
+    ],
+    "AXAPI" : [
+       [
+          "property",
+          "AXBrailleLabel",
+          "is",
+          "<value>"
+       ]
+    ],
+    "IAccessible2" : [
+       [
+          "property",
+          "objectAttributes",
+          "contains",
+          "braillelabel:<value>"
+       ]
+    ],
+    "UIA" : [
+       [
+          "property",
+          "AriaProperties.braillelabel",
+          "is",
+          "<value>"
+       ]
+    ]
+  },
+  "aria-errormessage": {
+    "Atspi" : [
+       [
+          "relation",
+          "RELATION_ERROR_MESSAGE",
+          "is",
+          "<id-list>"
+       ],
+       [
+          "reverseRelation",
+          "RELATION_ERROR_FOR",
+          "is",
+          "<id-list>"
+       ]
+
+    ],
+    "AXAPI" : [
+       [
+          "property",
+          "AXErrorMessageElements",
+          "is",
+          "<id-list>"
+       ]
+    ],
+    "IAccessible2" : [
+       [
+          "relation",
+          "IA2_RELATION_ERROR",
+          "is",
+          "<id-list>"
+       ],
+       [
+          "reverseRelation",
+          "IA2_RELATION_ERROR_FOR",
+          "is",
+          "<is-list>"
+       ]
+
+    ],
+    "UIA" : [
+       [
+          "property",
+          "ControllerFor",
+          "is",
+          "<id-list>"
+       ]
+    ]
+  }
+}

--- a/core-aam/json-test-example/scripts/role-map.js
+++ b/core-aam/json-test-example/scripts/role-map.js
@@ -1,0 +1,186 @@
+rolemap = {
+  "blockquote" : {
+    "Atspi" : [
+       [
+          "property",
+          "role",
+          "is",
+          "block quote"
+       ]
+    ],
+    "AXAPI" : [
+       [
+          "property",
+          "AXRole",
+          "is",
+          "AXGroup"
+       ],
+       [
+          "property",
+          "AXSubrole",
+          "is",
+          "<nil>"
+       ]
+    ],
+    "IAccessible2" : [
+       [
+          "property",
+          "role",
+          "is",
+          "IA2_ROLE_BLOCK_QUOTE"
+       ],
+       [
+          "property",
+          "msaaRole",
+          "is",
+          "ROLE_SYSTEM_GROUPING"
+       ]
+    ],
+    "UIA" : [
+       [
+          "property",
+          "ControlType",
+          "is",
+          "Group"
+       ],
+       [
+          "property",
+          "LocalizedControlType",
+          "is",
+          "blockquote"
+       ]
+    ]
+  },
+  "button_with_default_values_for_aria-pressed_and_aria-haspopup": {
+    "Atspi" : [
+       [
+          "property",
+          "role",
+          "is",
+          "push button"
+       ]
+    ],
+    "AXAPI" : [
+       [
+          "property",
+          "AXRole",
+          "is",
+          "AXButton"
+       ],
+       [
+          "property",
+          "AXSubrole",
+          "is",
+          "<nil>"
+       ]
+    ],
+    "IAccessible2" : [
+       [
+          "property",
+          "msaaRole",
+          "is",
+          "ROLE_SYSTEM_PUSHBUTTON"
+       ]
+    ],
+    "UIA" : [
+       [
+          "property",
+          "ControlType",
+          "is",
+          "Button"
+       ]
+    ]
+  },
+  "button_with_non_false_value_for_aria-haspopup" : {
+     "Atspi" : [
+        [
+           "property",
+           "role",
+           "is",
+           "push button"
+        ]
+     ],
+     "AXAPI" : [
+        [
+           "property",
+           "AXRole",
+           "is",
+           "AXPopUpButton"
+        ],
+        [
+           "property",
+           "AXSubrole",
+           "is",
+           "<nil>"
+        ],
+        [
+           "property",
+           "actions",
+           "contains",
+           "AXShowMenu"
+        ]
+     ],
+     "IAccessible2" : [
+        [
+           "property",
+           "msaaRole",
+           "is",
+           "ROLE_SYSTEM_PUSHBUTTON"
+        ]
+     ],
+     "UIA" : [
+        [
+           "property",
+           "ControlType",
+           "is",
+           "Button"
+        ]
+     ]
+  },
+  "button_with_defined_value_for_aria-pressed": {
+    "Atspi" : [
+       [
+          "property",
+          "role",
+          "is",
+          "toggle button"
+       ]
+    ],
+    "AXAPI" : [
+       [
+          "property",
+          "AXRole",
+          "is",
+          "AXCheckBox"
+       ],
+       [
+          "property",
+          "AXSubrole",
+          "is",
+          "AXToggle"
+       ]
+    ],
+    "IAccessible2" : [
+       [
+          "property",
+          "role",
+          "is",
+          "IA2_ROLE_TOGGLE_BUTTON"
+       ],
+      [
+          "property",
+          "msaaRole",
+          "is",
+          "ROLE_SYSTEM_PUSHBUTTON"
+       ]
+    ],
+    "UIA" : [
+       [
+          "property",
+          "ControlType",
+          "is",
+          "Button"
+       ]
+    ]
+  }
+}

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1080,6 +1080,21 @@
                 .then((jsonresult) => {
                   return JSON.parse(jsonresult);
                 });
+        },
+
+        /**
+         * Test properties of API's accessibility node.
+         *
+         * @param {id}         id of element
+         * @param {test}       an object of tests
+         * @param {api}        string indicating the API to test
+         * @returns {Promise}  The string "match" when the test succeeds,
+         *                     a failure message otherwise
+         */
+        test_accessibility_api: async function(dom_id, test, api) {
+            return window.test_driver_internal.test_accessibility_api(
+              dom_id, test, api, location.href
+            );
         }
     };
 
@@ -1272,6 +1287,11 @@
 
         async get_accessibility_api_node(dom_id, url) {
             throw new Error("get_accessibility_api_node() is not available.");
+        },
+
+        async test_accessibility_api(dom_id, test, api, url) {
+            throw new Error("test_accessibility_api() is not available.");
         }
+
     };
 })();

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -476,6 +476,20 @@ class GetAccessibilityAPINodeAction:
         url = payload["url"]
         return self.protocol.platform_accessibility.get_accessibility_api_node(dom_id, url)
 
+class TestAccessibilityAPIAction:
+    name = "test_accessibility_api"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        dom_id = payload["dom_id"]
+        test = payload["test"]
+        api = payload["api"]
+        url = payload["url"]
+        return self.protocol.platform_accessibility.test_accessibility_api(dom_id, test, api, url)
+
 
 actions = [ClickAction,
            DeleteAllCookiesAction,
@@ -513,4 +527,5 @@ actions = [ClickAction,
            GetVirtualSensorInformationAction,
            SetDevicePostureAction,
            ClearDevicePostureAction,
-           GetAccessibilityAPINodeAction]
+           GetAccessibilityAPINodeAction,
+           TestAccessibilityAPIAction]

--- a/tools/wptrunner/wptrunner/executors/executorplatformaccessibility.py
+++ b/tools/wptrunner/wptrunner/executors/executorplatformaccessibility.py
@@ -16,6 +16,15 @@ if platform == "win32":
     windows = True
     from .executorwindowsaccessibility import WindowsAccessibilityExecutorImpl
 
+def valid_api_for_platform(api):
+    if (linux and api == "Atspi"):
+        return True
+    if (mac and api == "AXAPI"):
+        return True
+    if (windows and (api == "UIA" or api == "IAccessible2")):
+        return True
+    return False
+
 class PlatformAccessibilityProtocolPart(ProtocolPart):
     """Protocol part for platform accessibility introspection"""
     name = "platform_accessibility"
@@ -35,3 +44,12 @@ class PlatformAccessibilityProtocolPart(ProtocolPart):
 
     def get_accessibility_api_node(self, dom_id, url):
         return self.impl.get_accessibility_api_node(dom_id, url)
+
+    def test_accessibility_api(self, dom_id, test, api, url):
+        # TODO: this is a bit of a hack, it will cause the test to
+        # "pass" with no assertions ran. We will use this until WPT supports
+        # some kind of "not applicable" test result.
+        if not valid_api_for_platform(api):
+          return ""
+
+        return self.impl.test_accessibility_api(dom_id, test, api, url)

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -339,4 +339,9 @@
     window.test_driver_internal.get_accessibility_api_node = function(dom_id, url) {
         return create_action("get_accessibility_api_node", {dom_id, url});
     };
+
+    window.test_driver_internal.test_accessibility_api = function(dom_id, test, api, url) {
+        return create_action("test_accessibility_api", {dom_id, test, api, url});
+    };
+
 })();


### PR DESCRIPTION
I'm using the `core-aam/acacia/json/` as a temporary directory for these tests.

These tests use [js object](https://github.com/Igalia/wpt/pull/14/files#diff-8e1057b8ca9721800071da9f9af4d4ad26eb3a7168ea7858b2d3db8b71deb35f) that contains an entry for each table in core-aam. So the tests are very simple:
```js
<div id=test role=blockquote>quote</div>

<script>
  AAMUtils.verifyAPI(
    'test',   /* dom id of object to test in accessibility tree */
    rolemap['blockquote'],   /* object representing all statements in https://w3c.github.io/core-aam/#blockquote */
    'role=blockquote'   /* string used in subtest name */
  );
</script>
```
Here is the result of this test: https://spectranaut.github.io/examples/wpt/role_blockquote_test.html

Right now the test has one subtest for each API, regardless of whether or not that API applies to platform the test is being run on.  The test was run on linux, so only the first test -- the test of the linux API `Atspi` -- is useful. The other tests aren't actually run (because you can't run a mac accessibility API test on linux), which you can see by expanding and seeing `No assertions run`. If you are curious about this design, [read more in this other PR's description](https://github.com/Igalia/wpt/pull/15)
